### PR TITLE
itail flag to open in current window

### DIFF
--- a/itail.el
+++ b/itail.el
@@ -99,7 +99,7 @@ clearing and filtering
   :keymap itail-keymap)
 
 ;;;###autoload
-(defun itail (file)
+(defun itail (file &optional current-window)
   "Tail file FILE in itail mode.  Supports remote tailing through tramp "
   (interactive "ftail file: ")
   (let* ((buffer-name (concat "tail " file))
@@ -109,7 +109,11 @@ clearing and filtering
                    (match-string 2 file)
                  (expand-file-name file))))
     (make-comint buffer-name "tail" nil "-F" file)
-    (pop-to-buffer (concat "*" buffer-name "*")))
+    (if current-window
+        (switch-to-buffer (concat "*" buffer-name "*"))
+        (pop-to-buffer (concat "*" buffer-name "*"))
+    )
+  )
   (ansi-color-for-comint-mode-on)
   (add-hook 'comint-preoutput-filter-functions 'itail-output-filter)
   (setq itail-file file)


### PR DESCRIPTION
Hi, hope you don't mind me submitting a pull request for this feature I am using at the moment 

Added an optional flag to tell itail to start tailing in the current
window instead of popping a new one.  Value of flag used to determine
whether pop-to-buffer or switch-to-buffer should be called. Defaults to
previous behaviour i.e. opening a new window.

I added this because I am putting together something that will automatically start tailing a list of logs - this is much easier if you have precise control over which window you want the tail in (i.e. go and create a bunch of windows then iterate through tailing each log file).
