### PR TITLE
Fix read-only buffer warnings

### DIFF
--- a/itail.el
+++ b/itail.el
@@ -166,7 +166,8 @@ clearing and filtering
 Very useful when the tail has had a great deal of information dumped
 to it and emacs can not keep up"
   (interactive)
-  (insert (concat "reloading " (buffer-name (current-buffer))))
+  (let ((inhibit-read-only t))
+    (insert (concat "reloading " (buffer-name (current-buffer)))))
   (itail-kill-with-process-sentinel 'itail-internal-reload))
 
 (defun itail-internal-reload (&rest ignored)
@@ -177,8 +178,9 @@ to it and emacs can not keep up"
   "Kill the tail process and close the buffer"
   (interactive)
   (when (yes-or-no-p "Really kill itail? ")
-    (insert (concat "killing " (buffer-name (current-buffer))))
-    (itail-kill-with-process-sentinel 'itail-internal-kill)))
+    (let ((inhibit-read-only t))
+      (insert (concat "killing " (buffer-name (current-buffer))))
+      (itail-kill-with-process-sentinel 'itail-internal-kill))))
 
 (defun itail-internal-kill (&rest ignored)
   (kill-buffer (current-buffer)))
@@ -194,8 +196,8 @@ to it and emacs can not keep up"
 (defun itail-clear ()
   "Clear out the tail buffer"
   (interactive)
-  (mark-whole-buffer)
-  (delete-region (point-min) (point-max)))
+  (let ((inhibit-read-only t))
+    (delete-region (point-min) (point-max))))
 
 (defun itail-toggle-filter (filter)
   "Add or remove FILTER to filter pipeline. For example, a filter of


### PR DESCRIPTION
I don't know if this is an emacs 26 thing, but these don't work w/o inhibiting read-only